### PR TITLE
Add session-based Render AI chat widget across site pages

### DIFF
--- a/assets/ai-chat-widget.css
+++ b/assets/ai-chat-widget.css
@@ -1,0 +1,176 @@
+.ai-chat-widget {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 2000;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.ai-chat-toggle {
+  width: 60px;
+  height: 60px;
+  border: 0;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #00a988 0%, #0d1b2a 100%);
+  color: #fff;
+  font-size: 24px;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(13, 27, 42, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ai-chat-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(13, 27, 42, 0.4);
+}
+
+.ai-chat-panel {
+  position: absolute;
+  right: 0;
+  bottom: 76px;
+  width: min(380px, calc(100vw - 24px));
+  height: min(560px, calc(100vh - 120px));
+  background: #fff;
+  border: 1px solid rgba(13, 27, 42, 0.12);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(13, 27, 42, 0.25);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.ai-chat-panel[hidden] {
+  display: none;
+}
+
+.ai-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 14px;
+  background: #0d1b2a;
+  color: #fff;
+}
+
+.ai-chat-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.ai-chat-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ai-chat-icon-btn {
+  border: 0;
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.ai-chat-icon-btn:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.ai-chat-messages {
+  flex: 1;
+  overflow: auto;
+  padding: 14px;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ai-chat-bubble {
+  max-width: 88%;
+  border-radius: 14px;
+  padding: 10px 12px;
+  font-size: 14px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ai-chat-bubble-user {
+  align-self: flex-end;
+  background: #0d1b2a;
+  color: #fff;
+  border-bottom-right-radius: 5px;
+}
+
+.ai-chat-bubble-assistant {
+  align-self: flex-start;
+  background: #fff;
+  color: #1a1a2e;
+  border: 1px solid rgba(13, 27, 42, 0.12);
+  border-bottom-left-radius: 5px;
+}
+
+.ai-chat-status {
+  min-height: 20px;
+  margin: 0;
+  padding: 0 14px 6px;
+  font-size: 12px;
+  color: #5a6a7a;
+}
+
+.ai-chat-form {
+  padding: 10px 10px 12px;
+  border-top: 1px solid rgba(13, 27, 42, 0.1);
+  background: #fff;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ai-chat-input {
+  flex: 1;
+  border: 1px solid rgba(13, 27, 42, 0.18);
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-size: 14px;
+  outline: none;
+}
+
+.ai-chat-input:focus {
+  border-color: #00a988;
+  box-shadow: 0 0 0 3px rgba(0, 169, 136, 0.14);
+}
+
+.ai-chat-send {
+  border: 0;
+  border-radius: 999px;
+  background: #00a988;
+  color: #fff;
+  font-weight: 600;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.ai-chat-send:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+@media (max-width: 640px) {
+  .ai-chat-widget {
+    right: 10px;
+    bottom: 10px;
+  }
+
+  .ai-chat-panel {
+    right: -2px;
+    bottom: 74px;
+    width: calc(100vw - 20px);
+    height: min(78vh, 540px);
+  }
+}

--- a/assets/ai-chat-widget.js
+++ b/assets/ai-chat-widget.js
@@ -1,0 +1,294 @@
+(function () {
+  "use strict";
+
+  var DEFAULT_CONFIG = {
+    startSessionUrl: "",
+    messageUrl: "",
+    endSessionUrl: "",
+    title: "Assistente Metodo Eureka",
+    welcomeMessage:
+      "Ciao! Sono l'assistente AI di Metodo Eureka. Scrivimi pure la tua domanda.",
+    placeholder: "Scrivi un messaggio...",
+    sendLabel: "Invia",
+    resetLabel: "Nuova chat"
+  };
+
+  var state = {
+    isOpen: false,
+    isSending: false,
+    sessionId: null
+  };
+
+  function resolveConfig() {
+    var customConfig = window.AIChatWidgetConfig || {};
+    return Object.assign({}, DEFAULT_CONFIG, customConfig);
+  }
+
+  function parseSessionId(payload) {
+    if (!payload || typeof payload !== "object") {
+      return null;
+    }
+
+    return (
+      payload.session_id ||
+      payload.sessionId ||
+      payload.id ||
+      (payload.data && (payload.data.session_id || payload.data.sessionId)) ||
+      null
+    );
+  }
+
+  function parseAssistantMessage(payload) {
+    if (!payload || typeof payload !== "object") {
+      return "Non sono riuscito a generare una risposta valida.";
+    }
+
+    return (
+      payload.display_text ||
+      payload.speech ||
+      payload.reply ||
+      payload.response ||
+      payload.message ||
+      payload.answer ||
+      (payload.data &&
+        (payload.data.display_text ||
+          payload.data.speech ||
+          payload.data.reply ||
+          payload.data.response ||
+          payload.data.message ||
+          payload.data.answer)) ||
+      (payload.result &&
+        (payload.result.display_text ||
+          payload.result.speech ||
+          payload.result.reply ||
+          payload.result.response ||
+          payload.result.message ||
+          payload.result.answer)) ||
+      "Non sono riuscito a generare una risposta valida."
+    );
+  }
+
+  function createElement(tag, className, text) {
+    var element = document.createElement(tag);
+    if (className) {
+      element.className = className;
+    }
+    if (typeof text === "string") {
+      element.textContent = text;
+    }
+    return element;
+  }
+
+  function appendMessage(messagesEl, role, text) {
+    var bubble = createElement(
+      "div",
+      "ai-chat-bubble " +
+        (role === "user" ? "ai-chat-bubble-user" : "ai-chat-bubble-assistant")
+    );
+    bubble.textContent = text;
+    messagesEl.appendChild(bubble);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  function setStatus(statusEl, text) {
+    statusEl.textContent = text || "";
+  }
+
+  async function ensureSession(config, statusEl) {
+    if (state.sessionId) {
+      return state.sessionId;
+    }
+
+    setStatus(statusEl, "Avvio sessione...");
+
+    var response = await fetch(config.startSessionUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({})
+    });
+
+    if (!response.ok) {
+      throw new Error("Impossibile avviare la sessione chat.");
+    }
+
+    var payload = await response.json();
+    var sessionId = parseSessionId(payload);
+
+    if (!sessionId) {
+      throw new Error("Risposta start session senza session_id.");
+    }
+
+    state.sessionId = sessionId;
+    setStatus(statusEl, "");
+    return sessionId;
+  }
+
+  async function endSession(config, statusEl, keepaliveOnly) {
+    if (!state.sessionId) {
+      return;
+    }
+
+    var currentSession = state.sessionId;
+    state.sessionId = null;
+
+    var body = JSON.stringify({ session_id: currentSession });
+
+    if (keepaliveOnly && navigator.sendBeacon) {
+      var blob = new Blob([body], { type: "application/json" });
+      navigator.sendBeacon(config.endSessionUrl, blob);
+      return;
+    }
+
+    try {
+      await fetch(config.endSessionUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: body,
+        keepalive: keepaliveOnly === true
+      });
+    } catch (_error) {
+      setStatus(statusEl, "Sessione chiusa localmente.");
+    }
+  }
+
+  function buildWidget(config) {
+    var root = createElement("div", "ai-chat-widget");
+
+    var toggleButton = createElement("button", "ai-chat-toggle", "AI");
+    toggleButton.type = "button";
+    toggleButton.setAttribute("aria-label", "Apri chat AI");
+
+    var panel = createElement("section", "ai-chat-panel");
+    panel.hidden = true;
+
+    var header = createElement("div", "ai-chat-header");
+    var title = createElement("h3", "ai-chat-title", config.title);
+    var actions = createElement("div", "ai-chat-header-actions");
+    var resetButton = createElement("button", "ai-chat-icon-btn", config.resetLabel);
+    var closeButton = createElement("button", "ai-chat-icon-btn", "Chiudi");
+    resetButton.type = "button";
+    closeButton.type = "button";
+    actions.appendChild(resetButton);
+    actions.appendChild(closeButton);
+    header.appendChild(title);
+    header.appendChild(actions);
+
+    var messagesEl = createElement("div", "ai-chat-messages");
+    appendMessage(messagesEl, "assistant", config.welcomeMessage);
+
+    var statusEl = createElement("p", "ai-chat-status", "");
+
+    var form = createElement("form", "ai-chat-form");
+    var input = createElement("input", "ai-chat-input");
+    input.type = "text";
+    input.placeholder = config.placeholder;
+    input.autocomplete = "off";
+
+    var sendButton = createElement("button", "ai-chat-send", config.sendLabel);
+    sendButton.type = "submit";
+
+    form.appendChild(input);
+    form.appendChild(sendButton);
+
+    panel.appendChild(header);
+    panel.appendChild(messagesEl);
+    panel.appendChild(statusEl);
+    panel.appendChild(form);
+
+    root.appendChild(panel);
+    root.appendChild(toggleButton);
+    document.body.appendChild(root);
+
+    toggleButton.addEventListener("click", function () {
+      state.isOpen = !state.isOpen;
+      panel.hidden = !state.isOpen;
+      if (state.isOpen) {
+        input.focus();
+      }
+    });
+
+    closeButton.addEventListener("click", function () {
+      state.isOpen = false;
+      panel.hidden = true;
+    });
+
+    resetButton.addEventListener("click", async function () {
+      setStatus(statusEl, "Chiusura sessione...");
+      await endSession(config, statusEl, false);
+      messagesEl.innerHTML = "";
+      appendMessage(messagesEl, "assistant", config.welcomeMessage);
+      setStatus(statusEl, "");
+    });
+
+    form.addEventListener("submit", async function (event) {
+      event.preventDefault();
+
+      var userText = input.value.trim();
+      if (!userText || state.isSending) {
+        return;
+      }
+
+      state.isSending = true;
+      sendButton.disabled = true;
+      appendMessage(messagesEl, "user", userText);
+      input.value = "";
+
+      try {
+        var sessionId = await ensureSession(config, statusEl);
+        setStatus(statusEl, "L'assistente sta rispondendo...");
+
+        var response = await fetch(config.messageUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            session_id: sessionId,
+            message: userText
+          })
+        });
+
+        if (!response.ok) {
+          throw new Error("Errore durante l'invio del messaggio.");
+        }
+
+        var payload = await response.json();
+        var assistantText = parseAssistantMessage(payload);
+        appendMessage(messagesEl, "assistant", assistantText);
+        setStatus(statusEl, "");
+      } catch (error) {
+        appendMessage(
+          messagesEl,
+          "assistant",
+          "Al momento non riesco a rispondere. Riprova tra qualche secondo."
+        );
+        setStatus(statusEl, (error && error.message) || "Errore chat.");
+      } finally {
+        state.isSending = false;
+        sendButton.disabled = false;
+      }
+    });
+
+    window.addEventListener("beforeunload", function () {
+      endSession(config, statusEl, true);
+    });
+  }
+
+  function init() {
+    var config = resolveConfig();
+    if (!config.startSessionUrl || !config.messageUrl || !config.endSessionUrl) {
+      return;
+    }
+    buildWidget(config);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/blog.html
+++ b/blog.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-2X3V7JZPBJ');</script>
@@ -393,5 +394,13 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script>
+window.AIChatWidgetConfig = {
+  startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+  messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+  endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 </body>
 </html>

--- a/coaching.html
+++ b/coaching.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-2X3V7JZPBJ');</script>
@@ -419,5 +420,13 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script>
+window.AIChatWidgetConfig = {
+  startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+  messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+  endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Montserrat:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <style>
 /* ============================
    DESIGN SYSTEM — LUXURY EDITION
@@ -1921,6 +1922,14 @@ document.querySelectorAll('#stats, #results, .stats-bar').forEach(el => observer
 /* ── Init ── */
 document.addEventListener('DOMContentLoaded', loadWebinar);
 </script>
+<script>
+window.AIChatWidgetConfig = {
+    startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+    messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+    endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 
 </body>
 </html>

--- a/libro.html
+++ b/libro.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-2X3V7JZPBJ');</script>
@@ -376,5 +377,13 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script>
+window.AIChatWidgetConfig = {
+  startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+  messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+  endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 </body>
 </html>

--- a/master-eureka.html
+++ b/master-eureka.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-2X3V7JZPBJ');</script>
@@ -444,5 +445,13 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script>
+window.AIChatWidgetConfig = {
+  startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+  messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+  endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 </body>
 </html>

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-2X3V7JZPBJ');</script>
@@ -468,5 +469,13 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script>
+window.AIChatWidgetConfig = {
+  startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+  messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+  endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 </body>
 </html>

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-2X3V7JZPBJ');</script>
@@ -415,5 +416,13 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script>
+window.AIChatWidgetConfig = {
+  startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+  messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+  endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 </body>
 </html>

--- a/testimonianze.html
+++ b/testimonianze.html
@@ -6,6 +6,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/ai-chat-widget.css">
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-2X3V7JZPBJ');</script>
@@ -385,5 +386,13 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script>
+window.AIChatWidgetConfig = {
+  startSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/start',
+  messageUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/message',
+  endSessionUrl: 'https://ai-chat-service-nls9.onrender.com/api/chat/session/end'
+};
+</script>
+<script src="assets/ai-chat-widget.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new client-side chat widget that makes network requests to external session/message endpoints on every page load/use, introducing UX/perf and availability/privacy considerations. Failures or API changes could impact page experience due to runtime fetch/sendBeacon behavior.
> 
> **Overview**
> Introduces a new floating AI chat widget (`assets/ai-chat-widget.js` + `.css`) with a toggleable panel, message history, status UI, and session lifecycle (start/message/end) managed via `fetch` and `beforeunload` cleanup.
> 
> Integrates the widget into core pages (`index.html`, `blog.html`, `coaching.html`, `libro.html`, `master-eureka.html`, `metodo-eureka.html`, `risorse-gratuite.html`, `testimonianze.html`) by adding the stylesheet, injecting `window.AIChatWidgetConfig` with Render API URLs, and loading the widget script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fba430b42f30d2d5de0c7d101ef3a059af438bf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->