### PR TITLE
Add chat-widget.js script tag to all pages for GitHub Pages production

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -393,5 +393,6 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>

--- a/coaching.html
+++ b/coaching.html
@@ -419,5 +419,6 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1921,5 +1921,6 @@ document.querySelectorAll('#stats, #results, .stats-bar').forEach(el => observer
 /* ── Init ── */
 document.addEventListener('DOMContentLoaded', loadWebinar);
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>

--- a/libro.html
+++ b/libro.html
@@ -376,5 +376,6 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>

--- a/master-eureka.html
+++ b/master-eureka.html
@@ -444,5 +444,6 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -468,5 +468,6 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -415,5 +415,6 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>

--- a/testimonianze.html
+++ b/testimonianze.html
@@ -385,5 +385,6 @@ const obs=new IntersectionObserver((entries)=>{
 },{threshold:0.2});
 document.querySelectorAll('.stats-section,[data-animate]').forEach(el=>obs.observe(el));
 </script>
+<script src="chat-widget.js"></script>
 </body>
 </html>


### PR DESCRIPTION
No data-api attribute needed: the widget defaults to the Render backend URL hardcoded in chat-widget.js. The mock-api.py server skips injection when the tag is already present.