### PR TITLE
Fix booking form slot display to show readable text

### DIFF
--- a/chat-widget.js
+++ b/chat-widget.js
@@ -1234,7 +1234,7 @@
     var slotInfo = document.createElement('div');
     slotInfo.className = 'ew-form-group';
     slotInfo.style.cssText = 'background:#F0EDE8;padding:10px 12px;border-radius:8px;margin-bottom:16px;';
-    slotInfo.innerHTML = '<strong>Orario selezionato:</strong><br>' + (slotData || 'Slot non specificato');
+    slotInfo.innerHTML = '<strong>Orario selezionato:</strong><br>' + (slotData.label || slotData.datetime || JSON.stringify(slotData) || 'Slot non specificato');
     body.appendChild(slotInfo);
 
     // Form fields


### PR DESCRIPTION
Fix booking form slot display to show readable text instead of [object Object]

Updated appendBookingForm function line 1237 to properly extract readable text from slotData object using fallback chain: slotData.label || slotData.datetime || JSON.stringify(slotData)

This ensures users see readable slot information ("martedì 31 marzo alle 09:00") in the booking form instead of [object Object].

Closes #35

Generated with [Claude Code](https://claude.ai/code)