### PR TITLE
Fix footer logo sizing and alignment across all pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -158,9 +158,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo{font-family:'Playfair Display',serif;font-size:19px;font-weight:700;
-  color:#fff;letter-spacing:.5px;margin-bottom:14px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -202,13 +201,13 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .hero{min-height:auto;padding:calc(var(--nav-h) + 40px) 0 60px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
 }
 </style>
 

--- a/coaching.html
+++ b/coaching.html
@@ -158,9 +158,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo{font-family:'Playfair Display',serif;font-size:19px;font-weight:700;
-  color:#fff;letter-spacing:.5px;margin-bottom:14px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -202,13 +201,13 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .hero{min-height:auto;padding:calc(var(--nav-h) + 40px) 0 60px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
 }
 </style>
 

--- a/lettura-veloce.html
+++ b/lettura-veloce.html
@@ -154,8 +154,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* FOOTER */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo-img{height:56px;width:auto;display:block;margin-bottom:8px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -184,12 +184,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .section{padding:64px 0;}
   .banner-navy,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
   .container{padding:0 16px;}
 }
 </style>

--- a/libro.html
+++ b/libro.html
@@ -158,9 +158,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo{font-family:'Playfair Display',serif;font-size:19px;font-weight:700;
-  color:#fff;letter-spacing:.5px;margin-bottom:14px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -202,13 +201,13 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .hero{min-height:auto;padding:calc(var(--nav-h) + 40px) 0 60px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
 }
 </style>
 

--- a/mappe-mentali.html
+++ b/mappe-mentali.html
@@ -154,8 +154,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* FOOTER */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo-img{height:56px;width:auto;display:block;margin-bottom:8px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -184,12 +184,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .section{padding:64px 0;}
   .banner-navy,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
   .container{padding:0 16px;}
 }
 </style>

--- a/master-eureka.html
+++ b/master-eureka.html
@@ -158,9 +158,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo{font-family:'Playfair Display',serif;font-size:19px;font-weight:700;
-  color:#fff;letter-spacing:.5px;margin-bottom:14px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -202,13 +201,13 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .hero{min-height:auto;padding:calc(var(--nav-h) + 40px) 0 60px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
 }
 </style>
 

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -158,9 +158,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo{font-family:'Playfair Display',serif;font-size:19px;font-weight:700;
-  color:#fff;letter-spacing:.5px;margin-bottom:14px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -202,13 +201,13 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .hero{min-height:auto;padding:calc(var(--nav-h) + 40px) 0 60px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
 }
 </style>
 

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -158,9 +158,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo{font-family:'Playfair Display',serif;font-size:19px;font-weight:700;
-  color:#fff;letter-spacing:.5px;margin-bottom:14px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -202,13 +201,13 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .hero{min-height:auto;padding:calc(var(--nav-h) + 40px) 0 60px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
 }
 </style>
 

--- a/tecniche-memoria.html
+++ b/tecniche-memoria.html
@@ -154,8 +154,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* FOOTER */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo-img{height:56px;width:auto;display:block;margin-bottom:8px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;margin-bottom:44px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -184,12 +184,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid{grid-template-columns:1fr;}
   .section{padding:64px 0;}
   .banner-navy,.banner-light{padding:32px 24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
   .container{padding:0 16px;}
 }
 </style>

--- a/testimonianze.html
+++ b/testimonianze.html
@@ -158,9 +158,8 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-inner{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:48px;margin-bottom:44px;}
-.footer-logo{font-family:'Playfair Display',serif;font-size:19px;font-weight:700;
-  color:#fff;letter-spacing:.5px;margin-bottom:14px;}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:14px;color:rgba(255,255,255,.6);line-height:1.8;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.4);
   margin-bottom:18px;text-transform:uppercase;letter-spacing:1.5px;}
@@ -209,14 +208,14 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .hamburger{display:flex;}
   .nav-menu{display:none;}
   .nav{padding:0 20px;}
-  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-inner,.testimonial-grid{grid-template-columns:1fr;}
+  .hero-inner,.grid-2,.grid-3,.grid-4,.stats-grid,.footer-grid,.testimonial-grid{grid-template-columns:1fr;}
   .hero{min-height:auto;padding:calc(var(--nav-h) + 40px) 0 60px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
   .testimonial-video-card{padding:24px;}
 }
 @media(max-width:600px){
-  .footer-inner{grid-template-columns:1fr 1fr;}
+  .footer-grid{grid-template-columns:1fr;}
 }
 </style>
 


### PR DESCRIPTION
- Fixed CSS selector mismatch between .footer-inner/.footer-logo and HTML structure
- Changed .footer-inner to .footer-grid to match HTML
- Changed .footer-logo to .footer-brand img with proper 48px height constraint
- Updated responsive CSS breakpoints consistently across all files
- Applied fixes to 10 HTML files: tecniche-memoria, metodo-eureka, lettura-veloce, mappe-mentali, master-eureka, libro, blog, coaching, testimonianze, risorse-gratuite

This resolves the oversized logo issue reported in the screenshot where footer logos were displaying at full size instead of the constrained 48px height used in index.html.

🤖 Generated with Claude Code