### PR TITLE
fix: update LinkedIn social media links across all HTML pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/coaching.html
+++ b/coaching.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/index.html
+++ b/index.html
@@ -1321,7 +1321,7 @@ body{
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/libro.html
+++ b/libro.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/master-eureka.html
+++ b/master-eureka.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/testimonianze.html
+++ b/testimonianze.html
@@ -261,7 +261,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]


### PR DESCRIPTION
Updated LinkedIn URLs from apprendimento-rapido to apprendimentorapido across 8 HTML pages to use the correct company profile URL.

Addresses issue #60

🤖 Generated with [Claude Code](https://claude.ai/code)