### PR TITLE
Fix footer privacy links styling consistency

### DIFF
--- a/Quiz_ test_memoria/index.html
+++ b/Quiz_ test_memoria/index.html
@@ -296,8 +296,9 @@ src="https://www.facebook.com/tr?id=1749584092436791&ev=PageView&noscript=1"
 }
 
 .footer-bottom p {
-    font-size: 12px;
-    color: rgba(255,255,255,.4);
+    font-size: 11px;
+    color: rgba(255,255,255,.2);
+    letter-spacing: .2px;
 }
 
 .footer-bottom div {
@@ -306,13 +307,15 @@ src="https://www.facebook.com/tr?id=1749584092436791&ev=PageView&noscript=1"
 }
 
 .footer-bottom a {
-    font-size: 12px;
-    color: rgba(255,255,255,.4);
+    font-size: 11px;
+    color: rgba(255,255,255,.3);
     text-decoration: none;
+    margin-left: 20px;
+    letter-spacing: .2px;
 }
 
 .footer-bottom a:hover {
-    color: rgba(255,255,255,.8);
+    color: var(--teal);
 }
 
 @media (max-width: 900px) {

--- a/Quiz_costo/index.html
+++ b/Quiz_costo/index.html
@@ -169,8 +169,9 @@ src="https://www.facebook.com/tr?id=1749584092436791&ev=PageView&noscript=1"
 }
 
 .footer-bottom p {
-    font-size: 12px;
-    color: rgba(255,255,255,.4);
+    font-size: 11px;
+    color: rgba(255,255,255,.2);
+    letter-spacing: .2px;
 }
 
 .footer-bottom div {
@@ -179,13 +180,15 @@ src="https://www.facebook.com/tr?id=1749584092436791&ev=PageView&noscript=1"
 }
 
 .footer-bottom a {
-    font-size: 12px;
-    color: rgba(255,255,255,.4);
+    font-size: 11px;
+    color: rgba(255,255,255,.3);
     text-decoration: none;
+    margin-left: 20px;
+    letter-spacing: .2px;
 }
 
 .footer-bottom a:hover {
-    color: rgba(255,255,255,.8);
+    color: var(--teal);
 }
 
 @media (max-width: 900px) {

--- a/black-friday/grazie.html
+++ b/black-friday/grazie.html
@@ -643,13 +643,13 @@
             </p>
             
             <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #e5e7eb;">
-                <a href="https://www.iubenda.com/privacy-policy/65797068" class="iubenda-white iubenda-noiframe iubenda-embed iubenda-noiframe" title="Privacy Policy" style="color: #3b82f6; text-decoration: none; margin: 0 10px; font-size: 14px;">Privacy Policy</a>
+                <a href="https://www.iubenda.com/privacy-policy/65797068" class="iubenda-white iubenda-noiframe iubenda-embed iubenda-noiframe" title="Privacy Policy" style="color: rgba(255,255,255,.3); text-decoration: none; margin-left: 20px; font-size: 11px; letter-spacing: .2px;">Privacy Policy</a>
                 <script type="text/javascript">(function (w,d) {var loader = function () {var s = d.createElement("script"), tag = d.getElementsByTagName("script")[0]; s.src="https://cdn.iubenda.com/iubenda.js"; tag.parentNode.insertBefore(s,tag);}; if(w.addEventListener){w.addEventListener("load", loader, false);}else if(w.attachEvent){w.attachEvent("onload", loader);}else{w.onload = loader;}})(window, document);</script>
                 
-                <a href="https://www.iubenda.com/privacy-policy/65797068/cookie-policy" class="iubenda-white iubenda-noiframe iubenda-embed iubenda-noiframe" title="Cookie Policy" style="color: #3b82f6; text-decoration: none; margin: 0 10px; font-size: 14px;">Cookie Policy</a>
+                <a href="https://www.iubenda.com/privacy-policy/65797068/cookie-policy" class="iubenda-white iubenda-noiframe iubenda-embed iubenda-noiframe" title="Cookie Policy" style="color: rgba(255,255,255,.3); text-decoration: none; margin-left: 20px; font-size: 11px; letter-spacing: .2px;">Cookie Policy</a>
                 <script type="text/javascript">(function (w,d) {var loader = function () {var s = d.createElement("script"), tag = d.getElementsByTagName("script")[0]; s.src="https://cdn.iubenda.com/iubenda.js"; tag.parentNode.insertBefore(s,tag);}; if(w.addEventListener){w.addEventListener("load", loader, false);}else if(w.attachEvent){w.attachEvent("onload", loader);}else{w.onload = loader;}})(window, document);</script>
                 
-                <a href="https://www.iubenda.com/termini-e-condizioni/65797068" class="iubenda-white iubenda-noiframe iubenda-embed iubenda-noiframe" title="Termini e Condizioni" style="color: #3b82f6; text-decoration: none; margin: 0 10px; font-size: 14px;">Termini e Condizioni</a>
+                <a href="https://www.iubenda.com/termini-e-condizioni/65797068" class="iubenda-white iubenda-noiframe iubenda-embed iubenda-noiframe" title="Termini e Condizioni" style="color: rgba(255,255,255,.3); text-decoration: none; margin-left: 20px; font-size: 11px; letter-spacing: .2px;">Termini e Condizioni</a>
                 <script type="text/javascript">(function (w,d) {var loader = function () {var s = d.createElement("script"), tag = d.getElementsByTagName("script")[0]; s.src="https://cdn.iubenda.com/iubenda.js"; tag.parentNode.insertBefore(s,tag);}; if(w.addEventListener){w.addEventListener("load", loader, false);}else if(w.attachEvent){w.attachEvent("onload", loader);}else{w.onload = loader;}})(window, document);</script>
             </div>
         </div>

--- a/black-friday/index.html
+++ b/black-friday/index.html
@@ -809,8 +809,9 @@
         }
 
         .footer-bottom p {
-            font-size: 12px;
-            color: rgba(255,255,255,.4);
+            font-size: 11px;
+            color: rgba(255,255,255,.2);
+            letter-spacing: .2px;
         }
 
         .footer-bottom div {
@@ -819,13 +820,15 @@
         }
 
         .footer-bottom a {
-            font-size: 12px;
-            color: rgba(255,255,255,.4);
+            font-size: 11px;
+            color: rgba(255,255,255,.3);
             text-decoration: none;
+            margin-left: 20px;
+            letter-spacing: .2px;
         }
 
         .footer-bottom a:hover {
-            color: rgba(255,255,255,.8);
+            color: #26a0a0;
         }
         
         /* Responsive */

--- a/blog.html
+++ b/blog.html
@@ -170,6 +170,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/coaching.html
+++ b/coaching.html
@@ -170,6 +170,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/lettura-veloce.html
+++ b/lettura-veloce.html
@@ -166,6 +166,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/libro.html
+++ b/libro.html
@@ -170,6 +170,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/mappe-mentali.html
+++ b/mappe-mentali.html
@@ -166,6 +166,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/master-eureka.html
+++ b/master-eureka.html
@@ -170,6 +170,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -170,6 +170,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -170,6 +170,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/tecniche-memoria.html
+++ b/tecniche-memoria.html
@@ -166,6 +166,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}

--- a/testimonianze.html
+++ b/testimonianze.html
@@ -170,6 +170,8 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
 .footer-bottom{border-top:1px solid rgba(255,255,255,.08);padding-top:26px;
   display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px;}
 .footer-bottom p{font-size:11px;color:rgba(255,255,255,.2);letter-spacing:.2px;}
+.footer-bottom a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
+.footer-bottom a:hover{color:var(--teal);}
 .footer-legal{display:flex;gap:20px;}
 .footer-legal a{font-size:11px;color:rgba(255,255,255,.3);text-decoration:none;margin-left:20px;letter-spacing:.2px;}
 .footer-legal a:hover{color:rgba(255,255,255,.8);}


### PR DESCRIPTION
Resolves #49

Fixed privacy links in footer across all pages to match index.html reference:
- Updated font-size from 12px/14px to 11px
- Changed color from bright blue to muted rgba(255,255,255,.3)
- Added missing margin-left:20px and letter-spacing:.2px
- Updated hover color to use brand teal instead of bright white
- Fixed 14 HTML files including main pages and subdirectories

Generated with [Claude Code](https://claude.ai/code)