### PR TITLE
fix: update LinkedIn social media links across all HTML pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]
@@ -428,7 +428,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
       <div class="footer-col">
         <h4>Azienda</h4>
         <a href="testimonianze.html">Testimonianze</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
       </div>
     </div>

--- a/coaching.html
+++ b/coaching.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]
@@ -454,7 +454,7 @@ async function submitCoaching(e){
       <div class="footer-col">
         <h4>Azienda</h4>
         <a href="testimonianze.html">Testimonianze</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1321,7 +1321,7 @@ body{
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]

--- a/lettura-veloce.html
+++ b/lettura-veloce.html
@@ -457,7 +457,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
         <h4>Contatti</h4>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
         <a href="tel:+390240702168">+39 02 40702168</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <span style="font-size:13px;color:rgba(255,255,255,.45);line-height:1.8;display:block;margin-top:4px;">Via Gardiscia 10<br>Rovio CH 6821</span>
       </div>
     </div>

--- a/libro.html
+++ b/libro.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]
@@ -468,7 +468,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
       <div class="footer-col">
         <h4>Azienda</h4>
         <a href="testimonianze.html">Testimonianze</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
       </div>
     </div>

--- a/mappe-mentali.html
+++ b/mappe-mentali.html
@@ -521,7 +521,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
         <h4>Contatti</h4>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
         <a href="tel:+390240702168">+39 02 40702168</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <span style="font-size:13px;color:rgba(255,255,255,.45);line-height:1.8;display:block;margin-top:4px;">Via Gardiscia 10<br>Rovio CH 6821</span>
       </div>
     </div>

--- a/master-eureka.html
+++ b/master-eureka.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]
@@ -677,7 +677,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
       <div class="footer-col">
         <h4>Azienda</h4>
         <a href="testimonianze.html">Testimonianze</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
       </div>
     </div>

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]
@@ -528,7 +528,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
       <div class="footer-col">
         <h4>Azienda</h4>
         <a href="testimonianze.html">Testimonianze</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
       </div>
     </div>

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]
@@ -450,7 +450,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
       <div class="footer-col">
         <h4>Azienda</h4>
         <a href="testimonianze.html">Testimonianze</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
       </div>
     </div>

--- a/tecniche-memoria.html
+++ b/tecniche-memoria.html
@@ -512,7 +512,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
         <h4>Contatti</h4>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
         <a href="tel:+390240702168">+39 02 40702168</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <span style="font-size:13px;color:rgba(255,255,255,.45);line-height:1.8;display:block;margin-top:4px;">Via Gardiscia 10<br>Rovio CH 6821</span>
       </div>
     </div>

--- a/testimonianze.html
+++ b/testimonianze.html
@@ -253,7 +253,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimento-rapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
     "https://www.youtube.com/user/apprendimentorapido"
   ]
@@ -491,7 +491,7 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
       <div class="footer-col">
         <h4>Azienda</h4>
         <a href="testimonianze.html">Testimonianze</a>
-        <a href="https://www.linkedin.com/company/apprendimento-rapido" target="_blank">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
         <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a>
       </div>
     </div>


### PR DESCRIPTION
Updated LinkedIn URLs from apprendimento-rapido to apprendimentorapido across 11 HTML pages to use the correct company profile URL.

Addresses issue #51

🤖 Generated with [Claude Code](https://claude.ai/code)