### PR TITLE
fix: correct LinkedIn URLs and add Instagram social media links

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);
@@ -255,9 +255,10 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -442,6 +443,14 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 

--- a/coaching.html
+++ b/coaching.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);
@@ -255,9 +255,10 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -468,6 +469,14 @@ async function submitCoaching(e){
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -1187,7 +1187,7 @@ body{
 
 .footer-grid{
     display:grid;
-    grid-template-columns:1.5fr 1fr 1fr 1fr;
+    grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;
     gap:40px;
     padding-bottom:56px;
     border-bottom:1px solid rgba(255,255,255,.06);
@@ -1251,7 +1251,7 @@ body{
    ============================ */
 @media(max-width:1024px){
     .tools-grid{grid-template-columns:repeat(2,1fr);}
-    .footer-grid{grid-template-columns:1fr 1fr;}
+    .footer-grid{grid-template-columns:1fr 1fr 1fr;}
 }
 
 @media(max-width:860px){
@@ -1321,9 +1321,10 @@ body{
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -1996,6 +1997,14 @@ body{
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 

--- a/libro.html
+++ b/libro.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);
@@ -255,9 +255,10 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -482,6 +483,14 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 

--- a/master-eureka.html
+++ b/master-eureka.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);
@@ -255,9 +255,10 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -691,6 +692,14 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);
@@ -255,9 +255,10 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -542,6 +543,14 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);
@@ -255,9 +255,10 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -464,6 +465,14 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 

--- a/testimonianze.html
+++ b/testimonianze.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* ── FOOTER ── */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);
@@ -263,9 +263,10 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     "reviewCount": "20000"
   },
   "sameAs": [
-    "https://www.linkedin.com/company/apprendimentorapido",
+    "https://www.linkedin.com/company/apprendimentorapido/",
     "https://www.facebook.com/apprendimentorapido",
-    "https://www.youtube.com/user/apprendimentorapido"
+    "https://www.youtube.com/user/apprendimentorapido",
+    "https://www.instagram.com/apprendimento_rapido/"
   ]
 }
 </script>
@@ -608,6 +609,14 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
                     <a href="tel:+390240702168">+390240702168</a><br>
                     Lun–Ven 9:00–18:30
                 </div>
+            </div>
+
+            <div class="footer-col">
+                <h4>Seguici</h4>
+                <a href="https://www.linkedin.com/company/apprendimentorapido/" target="_blank">LinkedIn</a>
+                <a href="https://www.instagram.com/apprendimento_rapido/" target="_blank">Instagram</a>
+                <a href="https://www.facebook.com/apprendimentorapido" target="_blank">Facebook</a>
+                <a href="https://www.youtube.com/user/apprendimentorapido" target="_blank">YouTube</a>
             </div>
         </div>
 


### PR DESCRIPTION
Updated LinkedIn URLs to include trailing slash and added Instagram social media links across all main HTML pages.

## Changes:
- Updated LinkedIn URLs to `https://www.linkedin.com/company/apprendimentorapido/`
- Added Instagram to JSON-LD sameAs arrays: `https://www.instagram.com/apprendimento_rapido/`
- Added 'Seguici' social media footer section with all platforms
- Updated CSS grid layouts to accommodate new social media column

## Files Updated:
- index.html
- blog.html
- coaching.html
- libro.html
- master-eureka.html
- metodo-eureka.html
- risorse-gratuite.html
- testimonianze.html

Addresses issue #60

🤖 Generated with [Claude Code](https://claude.ai/code)