### PR TITLE
feat: add AI chat widget to article pages

### DIFF
--- a/wp-content/themes/kadence-child/footer.php
+++ b/wp-content/themes/kadence-child/footer.php
@@ -78,5 +78,10 @@ do_action( 'kadence_after_content' );
 <?php do_action( 'kadence_after_wrapper' ); ?>
 
 <?php wp_footer(); ?>
+
+<!-- AI Chat Widget -->
+<script src="<?php echo esc_url(home_url('/chat-widget.js')); ?>"></script>
+<script src="<?php echo esc_url(home_url('/whatsapp-widget.js')); ?>"></script>
+
 </body>
 </html>


### PR DESCRIPTION
**Summary**
- Add AI chat widget to WordPress child theme footer
- Ensures chat appears on all dedicated article pages
- Maintains consistency with static blog page implementation

**Problem Solved**
The AI chat widget was missing from WordPress-served article pages, preventing lead capture from high-value article readers.

**Changes**
- Modified `wp-content/themes/kadence-child/footer.php`
- Added chat-widget.js and whatsapp-widget.js scripts
- Used proper WordPress URL functions for security

Fixes ##71

🤖 Generated with [Claude Code](https://claude.ai/code)