### PR TITLE
Fix footer layout: align Seguici column with other columns

### DIFF
--- a/lettura-veloce.html
+++ b/lettura-veloce.html
@@ -154,7 +154,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* FOOTER */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);

--- a/mappe-mentali.html
+++ b/mappe-mentali.html
@@ -154,7 +154,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* FOOTER */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);

--- a/tecniche-memoria.html
+++ b/tecniche-memoria.html
@@ -154,7 +154,7 @@ body{font-family:'Inter',sans-serif;background:var(--off-white);color:var(--text
 
 /* FOOTER */
 footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
-.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:40px;margin-bottom:44px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
+.footer-grid{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr 1fr;gap:40px;margin-bottom:44px;padding-bottom:56px;border-bottom:1px solid rgba(255,255,255,.06);}
 .footer-brand img{height:48px;width:auto;display:block;margin-bottom:18px;opacity:.9;}
 .footer-brand p{font-size:13px;color:rgba(255,255,255,.4);line-height:1.75;max-width:240px;}
 .footer-col h4{font-size:11px;font-weight:700;color:rgba(255,255,255,.6);


### PR DESCRIPTION
Fixes footer layout issue where the "Seguici" column was wrapping to a new line on specific pages.

## Problem
Three pages had incorrect CSS grid definition for footer:
- `tecniche-memoria.html`
- `lettura-veloce.html`
- `mappe-mentali.html`

These pages used 4 columns instead of 5 columns like `index.html`, causing the "Seguici" column to wrap.

## Solution
Updated `.footer-grid` CSS rule to use 5 columns:
```css
grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; /* Added missing 1fr */
```

## Result
- Footer displays consistently across all pages
- All 5 columns stay inline as intended
- Layout matches `index.html` exactly

Generated with [Claude Code](https://claude.ai/code)