### PR TITLE
Add CSS fix for header site-container flex layout

### DIFF
--- a/wp-content/themes/kadence-child/style.css
+++ b/wp-content/themes/kadence-child/style.css
@@ -973,3 +973,8 @@ body #masthead .site-main-header-inner-wrap {
   padding: 0 40px !important;
 }
 
+/* Fix site-container larghezza header */
+#main-header .site-container {
+  flex: 1 1 auto !important;
+}
+


### PR DESCRIPTION
Fixes #143

Adds CSS rule to fix header layout spacing between logo and menu:

- Adds `flex: 1 1 auto !important` to `#main-header .site-container`
- Makes site-container expand to full width available
- Ensures logo goes to left and menu aligns to right

Generated with [Claude Code](https://claude.ai/code)