### PR TITLE
Fix header layout: expand intermediate wrapper

### DIFF
--- a/wp-content/themes/kadence-child/style.css
+++ b/wp-content/themes/kadence-child/style.css
@@ -978,3 +978,8 @@ body #masthead .site-main-header-inner-wrap {
   flex: 1 1 auto !important;
 }
 
+/* Fix 2: espande il wrapper intermedio che blocca la larghezza */
+.site-header-inner-wrap > .site-header-upper-wrap {
+  flex: 1 1 auto;
+}
+


### PR DESCRIPTION
Added CSS rule to expand .site-header-upper-wrap that was blocking header width:
- .site-header-inner-wrap > .site-header-upper-wrap { flex: 1 1 auto }

This allows the header to grow to 1840px and enables proper space-between layout with logo on left and menu on right.

Closes #147

🤖 Generated with [Claude Code](https://claude.ai/code)