### PR TITLE
Fix: improve "articoli simili" card layout and spacing

### DIFF
--- a/wp-content/themes/kadence-child/style.css
+++ b/wp-content/themes/kadence-child/style.css
@@ -978,3 +978,31 @@ body #masthead .site-main-header-inner-wrap {
   flex: 1 1 auto !important;
 }
 
+/* Fix: Articoli simili - card troppo strette */
+
+.entry-related .entry-header {
+  padding-left: 12px !important;
+  padding-right: 12px !important;
+  padding-top: 16px !important;
+  padding-bottom: 16px !important;
+}
+
+.entry-related .entry-content-wrap {
+  padding: 12px !important;
+}
+
+.entry-related-inner-content {
+  max-width: 100% !important;
+  width: 100% !important;
+}
+
+.entry-related .splide__list {
+  grid-template-columns: repeat(3, 1fr) !important;
+  gap: 24px !important;
+}
+
+.entry-related .splide__slide {
+  min-width: unset !important;
+  width: auto !important;
+}
+


### PR DESCRIPTION
This PR fixes the spacing and layout issues with the "articoli simili" (related articles) cards.

## Changes
- Fixed card padding and spacing for related articles section
- Updated grid layout for better visual consistency
- Removed minimum width restrictions on slide elements

Closes #151

Generated with [Claude Code](https://claude.ai/code)