### PR TITLE
Fix: Aggiungi campi mancanti quiz costo a test_results

### DIFF
--- a/chat-widget.js
+++ b/chat-widget.js
@@ -984,8 +984,18 @@
       session_extra: quizParams.quiz_status ? {
         test_results: {
           quiz_status: quizParams.quiz_status,
-          pam: quizParams.pam,
-          punteggio: quizParams.punteggio
+          pam: quizParams.pam || null,
+          punteggio: quizParams.punteggio || null,
+          punteggio1: quizParams.punteggio1 || null,
+          punteggio2: quizParams.punteggio2 || null,
+          miglioramento: quizParams.miglioramento || null,
+          fatturato_attuale: quizParams.fatturato_attuale || null,
+          fatturato_potenziale: quizParams.fatturato_potenziale || null,
+          crescita_potenziale: quizParams.crescita_potenziale || null,
+          criticita_opportunita: quizParams.criticita_opportunita || null,
+          criticita_inefficienza: quizParams.criticita_inefficienza || null,
+          criticita_competitivita: quizParams.criticita_competitivita || null,
+          criticita_innovazione: quizParams.criticita_innovazione || null
         }
       } : null
     };
@@ -1079,8 +1089,18 @@
             session_extra: quizParams.quiz_status ? {
               test_results: {
                 quiz_status: quizParams.quiz_status,
-                pam: quizParams.pam,
-                punteggio: quizParams.punteggio
+                pam: quizParams.pam || null,
+                punteggio: quizParams.punteggio || null,
+                punteggio1: quizParams.punteggio1 || null,
+                punteggio2: quizParams.punteggio2 || null,
+                miglioramento: quizParams.miglioramento || null,
+                fatturato_attuale: quizParams.fatturato_attuale || null,
+                fatturato_potenziale: quizParams.fatturato_potenziale || null,
+                crescita_potenziale: quizParams.crescita_potenziale || null,
+                criticita_opportunita: quizParams.criticita_opportunita || null,
+                criticita_inefficienza: quizParams.criticita_inefficienza || null,
+                criticita_competitivita: quizParams.criticita_competitivita || null,
+                criticita_innovazione: quizParams.criticita_innovazione || null
               }
             } : null
           };
@@ -2450,8 +2470,18 @@
         session_extra: quizParams.quiz_status ? {
           test_results: {
             quiz_status: quizParams.quiz_status,
-            pam: quizParams.pam,
-            punteggio: quizParams.punteggio
+            pam: quizParams.pam || null,
+            punteggio: quizParams.punteggio || null,
+            punteggio1: quizParams.punteggio1 || null,
+            punteggio2: quizParams.punteggio2 || null,
+            miglioramento: quizParams.miglioramento || null,
+            fatturato_attuale: quizParams.fatturato_attuale || null,
+            fatturato_potenziale: quizParams.fatturato_potenziale || null,
+            crescita_potenziale: quizParams.crescita_potenziale || null,
+            criticita_opportunita: quizParams.criticita_opportunita || null,
+            criticita_inefficienza: quizParams.criticita_inefficienza || null,
+            criticita_competitivita: quizParams.criticita_competitivita || null,
+            criticita_innovazione: quizParams.criticita_innovazione || null
           }
         } : null
       };


### PR DESCRIPTION
Aggiornato chat-widget.js per includere tutti i campi del quiz 'costo_ignoranza':
- fatturato_attuale, fatturato_potenziale, crescita_potenziale
- criticita_opportunita, criticita_inefficienza, criticita_competitivita, criticita_innovazione
- punteggio1, punteggio2, miglioramento

Risolve il problema dei dati a zero nel backend per il quiz costo.

Generated with [Claude Code](https://claude.ai/code)