### PR TITLE
Fix layout overflow in "Articoli simili" section

### DIFF
--- a/wp-content/themes/kadence-child/style.css
+++ b/wp-content/themes/kadence-child/style.css
@@ -1004,14 +1004,19 @@ body #masthead .site-main-header-inner-wrap {
   width: 100% !important;
 }
 
-/* Articoli simili: 2 card per riga */
 .entry-related .splide__list {
-  grid-template-columns: repeat(2, 1fr) !important;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  display: grid !important;
 }
 
 .entry-related .splide__slide {
-  min-width: unset !important;
   width: auto !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+}
+
+.entry-related .entry-related-carousel {
+  overflow: hidden;
 }
 
 


### PR DESCRIPTION
Fix layout overflow in "Articoli simili" section

- Updated .splide__list to use minmax(0, 1fr) to prevent overflow
- Added overflow: hidden to .entry-related-carousel container
- Enhanced slide width constraints to work with JavaScript inline styles

Closes #155

🤖 Generated with [Claude Code](https://claude.ai/code)