### PR TITLE
Fix conflicting CSS rules for "Articoli simili" section

### DIFF
--- a/wp-content/themes/kadence-child/style.css
+++ b/wp-content/themes/kadence-child/style.css
@@ -850,11 +850,8 @@ body #masthead .site-branding .brand {
 
 .entry-related .entry-related-carousel .splide__list.kadence-posts-list {
   display: grid !important;
-  grid-template-columns: repeat(3, 1fr) !important;
-  gap: 24px !important;
-  list-style: none !important;
-  margin: 0 !important;
-  padding: 0 !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  gap: 16px !important;
   width: 100% !important;
   transform: none !important;
 }
@@ -1004,10 +1001,6 @@ body #masthead .site-main-header-inner-wrap {
   width: 100% !important;
 }
 
-.entry-related .splide__list {
-  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-  display: grid !important;
-}
 
 .entry-related .splide__slide {
   width: auto !important;


### PR DESCRIPTION
Fix conflicting CSS rules for "Articoli simili" section

- Remove redundant .entry-related .splide__list rule that was causing conflicts
- Update .kadence-posts-list rule to use minmax(0, 1fr) to prevent overflow
- Reduce gap from 24px to 16px to avoid clipping of third card

Closes #155

🤖 Generated with [Claude Code](https://claude.ai/code)