### PR TITLE
Add strategic CTA banners to first 6 HTML pages

### DIFF
--- a/coaching.html
+++ b/coaching.html
@@ -209,6 +209,47 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
+.banner{
+  width:100%;
+  min-height:140px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:32px 24px;
+  border-radius:16px;
+  background:linear-gradient(160deg,#0D1B2A 0%,#1C2B3A 100%);
+  box-shadow:0 16px 48px rgba(13,27,42,.15);
+  border:1px solid rgba(255,255,255,.08);
+  margin:40px 0;
+  cursor:pointer;
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+}
+.banner:hover{
+  transform:translateY(-3px);
+  box-shadow:0 20px 56px rgba(13,27,42,.22);
+}
+.banner h1{
+  font-family:'Playfair Display',serif;
+  font-size:clamp(1.8rem,4.5vw,3.2rem);
+  line-height:1.1;
+  font-weight:700;
+  color:#fff;
+  letter-spacing:-0.02em;
+  margin:0;
+}
+.banner h1 em{
+  color:#B8973E;
+  font-style:italic;
+  font-weight:700;
+}
+@media(max-width:768px){
+.banner{
+  min-height:120px;
+  padding:24px 16px;
+  margin:32px 0;
+}
+}
 @media(max-width:600px){
   .footer-grid{grid-template-columns:1fr;}
 }
@@ -352,6 +393,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_costo/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test del <em>Costo dell'Ignoranza</em></h1>
+</section>
+</a>
 
 <!-- Form -->
 <section class="section bg-light" id="prenota">

--- a/lettura-veloce.html
+++ b/lettura-veloce.html
@@ -191,6 +191,47 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-light{padding:32px 24px;}
 }
+.banner{
+  width:100%;
+  min-height:140px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:32px 24px;
+  border-radius:16px;
+  background:linear-gradient(160deg,#0D1B2A 0%,#1C2B3A 100%);
+  box-shadow:0 16px 48px rgba(13,27,42,.15);
+  border:1px solid rgba(255,255,255,.08);
+  margin:40px 0;
+  cursor:pointer;
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+}
+.banner:hover{
+  transform:translateY(-3px);
+  box-shadow:0 20px 56px rgba(13,27,42,.22);
+}
+.banner h1{
+  font-family:'Playfair Display',serif;
+  font-size:clamp(1.8rem,4.5vw,3.2rem);
+  line-height:1.1;
+  font-weight:700;
+  color:#fff;
+  letter-spacing:-0.02em;
+  margin:0;
+}
+.banner h1 em{
+  color:#B8973E;
+  font-style:italic;
+  font-weight:700;
+}
+@media(max-width:768px){
+.banner{
+  min-height:120px;
+  padding:24px 16px;
+  margin:32px 0;
+}
+}
 @media(max-width:600px){
   .footer-grid{grid-template-columns:1fr;}
   .container{padding:0 16px;}
@@ -299,6 +340,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_lettura/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test di <em>Lettura</em></h1>
+</section>
+</a>
 
 <!-- COSA E' -->
 <section class="section bg-off" id="cosa-e">

--- a/mappe-mentali.html
+++ b/mappe-mentali.html
@@ -191,6 +191,47 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-light{padding:32px 24px;}
 }
+.banner{
+  width:100%;
+  min-height:140px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:32px 24px;
+  border-radius:16px;
+  background:linear-gradient(160deg,#0D1B2A 0%,#1C2B3A 100%);
+  box-shadow:0 16px 48px rgba(13,27,42,.15);
+  border:1px solid rgba(255,255,255,.08);
+  margin:40px 0;
+  cursor:pointer;
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+}
+.banner:hover{
+  transform:translateY(-3px);
+  box-shadow:0 20px 56px rgba(13,27,42,.22);
+}
+.banner h1{
+  font-family:'Playfair Display',serif;
+  font-size:clamp(1.8rem,4.5vw,3.2rem);
+  line-height:1.1;
+  font-weight:700;
+  color:#fff;
+  letter-spacing:-0.02em;
+  margin:0;
+}
+.banner h1 em{
+  color:#B8973E;
+  font-style:italic;
+  font-weight:700;
+}
+@media(max-width:768px){
+.banner{
+  min-height:120px;
+  padding:24px 16px;
+  margin:32px 0;
+}
+}
 @media(max-width:600px){
   .footer-grid{grid-template-columns:1fr;}
   .container{padding:0 16px;}
@@ -299,6 +340,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_memoria/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test di <em>Memoria</em></h1>
+</section>
+</a>
 
 <!-- COSA SONO -->
 <section class="section bg-off" id="cosa-sono">

--- a/metodo-eureka.html
+++ b/metodo-eureka.html
@@ -209,6 +209,47 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
+.banner{
+  width:100%;
+  min-height:140px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:32px 24px;
+  border-radius:16px;
+  background:linear-gradient(160deg,#0D1B2A 0%,#1C2B3A 100%);
+  box-shadow:0 16px 48px rgba(13,27,42,.15);
+  border:1px solid rgba(255,255,255,.08);
+  margin:40px 0;
+  cursor:pointer;
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+}
+.banner:hover{
+  transform:translateY(-3px);
+  box-shadow:0 20px 56px rgba(13,27,42,.22);
+}
+.banner h1{
+  font-family:'Playfair Display',serif;
+  font-size:clamp(1.8rem,4.5vw,3.2rem);
+  line-height:1.1;
+  font-weight:700;
+  color:#fff;
+  letter-spacing:-0.02em;
+  margin:0;
+}
+.banner h1 em{
+  color:#B8973E;
+  font-style:italic;
+  font-weight:700;
+}
+@media(max-width:768px){
+.banner{
+  min-height:120px;
+  padding:24px 16px;
+  margin:32px 0;
+}
+}
 @media(max-width:600px){
   .footer-grid{grid-template-columns:1fr;}
 }
@@ -399,6 +440,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   </div>
 </section>
 
+<a href="/quiz_test_lettura/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test di <em>Lettura</em></h1>
+</section>
+</a>
+
 <!-- 4 Pillars -->
 <section class="section bg-off">
   <div class="container">
@@ -439,6 +486,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_memoria/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test di <em>Memoria</em></h1>
+</section>
+</a>
 
 <!-- Formula ibrida -->
 <section class="section bg-white">
@@ -495,6 +548,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_costo/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test del <em>Costo dell'Ignoranza</em></h1>
+</section>
+</a>
 
 <!-- CTA -->
 <section class="section" style="background:var(--navy);">

--- a/risorse-gratuite.html
+++ b/risorse-gratuite.html
@@ -209,6 +209,47 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-gold,.banner-light{padding:32px 24px;}
 }
+.banner{
+  width:100%;
+  min-height:140px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:32px 24px;
+  border-radius:16px;
+  background:linear-gradient(160deg,#0D1B2A 0%,#1C2B3A 100%);
+  box-shadow:0 16px 48px rgba(13,27,42,.15);
+  border:1px solid rgba(255,255,255,.08);
+  margin:40px 0;
+  cursor:pointer;
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+}
+.banner:hover{
+  transform:translateY(-3px);
+  box-shadow:0 20px 56px rgba(13,27,42,.22);
+}
+.banner h1{
+  font-family:'Playfair Display',serif;
+  font-size:clamp(1.8rem,4.5vw,3.2rem);
+  line-height:1.1;
+  font-weight:700;
+  color:#fff;
+  letter-spacing:-0.02em;
+  margin:0;
+}
+.banner h1 em{
+  color:#B8973E;
+  font-style:italic;
+  font-weight:700;
+}
+@media(max-width:768px){
+.banner{
+  min-height:120px;
+  padding:24px 16px;
+  margin:32px 0;
+}
+}
 @media(max-width:600px){
   .footer-grid{grid-template-columns:1fr;}
 }
@@ -321,6 +362,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   </div>
 </section>
 
+<a href="/quiz_test_lettura/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test di <em>Lettura</em></h1>
+</section>
+</a>
+
 <!-- Test livello -->
 <section class="section bg-white">
   <div class="container">
@@ -369,6 +416,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_memoria/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test di <em>Memoria</em></h1>
+</section>
+</a>
 
 <!-- Webinar banner -->
 <section class="section bg-light">
@@ -421,6 +474,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_costo/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test del <em>Costo dell'Ignoranza</em></h1>
+</section>
+</a>
 
 <section class="section" style="background:var(--navy);text-align:center;">
   <div class="container" style="max-width:600px;">

--- a/tecniche-memoria.html
+++ b/tecniche-memoria.html
@@ -191,6 +191,47 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
   .section{padding:64px 0;}
   .banner-navy,.banner-light{padding:32px 24px;}
 }
+.banner{
+  width:100%;
+  min-height:140px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:32px 24px;
+  border-radius:16px;
+  background:linear-gradient(160deg,#0D1B2A 0%,#1C2B3A 100%);
+  box-shadow:0 16px 48px rgba(13,27,42,.15);
+  border:1px solid rgba(255,255,255,.08);
+  margin:40px 0;
+  cursor:pointer;
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+}
+.banner:hover{
+  transform:translateY(-3px);
+  box-shadow:0 20px 56px rgba(13,27,42,.22);
+}
+.banner h1{
+  font-family:'Playfair Display',serif;
+  font-size:clamp(1.8rem,4.5vw,3.2rem);
+  line-height:1.1;
+  font-weight:700;
+  color:#fff;
+  letter-spacing:-0.02em;
+  margin:0;
+}
+.banner h1 em{
+  color:#B8973E;
+  font-style:italic;
+  font-weight:700;
+}
+@media(max-width:768px){
+.banner{
+  min-height:120px;
+  padding:24px 16px;
+  margin:32px 0;
+}
+}
 @media(max-width:600px){
   .footer-grid{grid-template-columns:1fr;}
   .container{padding:0 16px;}
@@ -299,6 +340,12 @@ footer{background:var(--navy);color:rgba(255,255,255,.75);padding:56px 0 32px;}
     </div>
   </div>
 </section>
+
+<a href="/quiz_test_memoria/" style="display:block;text-decoration:none;">
+<section class="banner">
+  <h1>Test di <em>Memoria</em></h1>
+</section>
+</a>
 
 <!-- COSA SONO -->
 <section class="section bg-off" id="cosa-sono">


### PR DESCRIPTION
Implemented banner placements based on CRO principles for first 6 pages only:

🎯 Strategic Placements:
- lettura-veloce.html: Test Lettura after problem section
- tecniche-memoria.html: Test Memoria after problem section
- mappe-mentali.html: Test Memoria after problem section
- coaching.html: Test Costo after 3-step process
- risorse-gratuite.html: All 3 banners at strategic intervals
- metodo-eureka.html: All 3 banners after key content sections

❌ **master-eureka.html** → **NOT MODIFIED** (as requested)

🎨 Features:
- Responsive design with adapted dimensions for mobile
- Smooth hover animations with transform and shadow effects
- Strategic placement at moments of maximum emotional readiness
- Consistent styling across all 6 pages

Fixes #167

Generated with [Claude Code](https://claude.ai/code)