### PR TITLE
Self-service appointment: pagina pubblica /appuntamento/ (HTML + CSS …

### DIFF
--- a/appuntamento/index.html
+++ b/appuntamento/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestione appuntamento — Apprendimento Rapido</title>
+    <meta name="robots" content="noindex,nofollow">
+    <meta name="backend-url" content="https://ai-call-system-1.onrender.com">
+
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2X3V7JZPBJ"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-2X3V7JZPBJ');
+    </script>
+
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="page" id="page" aria-live="polite">
+        <header class="brand">
+            <h1>Apprendimento Rapido</h1>
+        </header>
+        <section id="stage" class="stage">
+            <div class="loader" role="status" aria-label="Caricamento">
+                <div class="spinner"></div>
+                <p>Verifica del link in corso...</p>
+            </div>
+        </section>
+        <footer class="brand-footer">
+            <p>Bisogno di aiuto? Scrivi a <a href="mailto:info@apprendimentorapido.it">info@apprendimentorapido.it</a></p>
+        </footer>
+    </main>
+
+    <script src="manage.js"></script>
+</body>
+</html>

--- a/appuntamento/manage.js
+++ b/appuntamento/manage.js
@@ -1,0 +1,426 @@
+/* Self-service gestione appuntamento — vanilla JS, niente librerie esterne. */
+(function () {
+    'use strict';
+
+    var stage = document.getElementById('stage');
+    var qs = new URLSearchParams(window.location.search);
+    var token = qs.get('token') || '';
+    var mockMode = qs.get('mock') || '';
+
+    var BACKEND_URL = (function () {
+        var meta = document.querySelector('meta[name="backend-url"]');
+        return (meta && meta.getAttribute('content')) || 'https://ai-call-system-1.onrender.com';
+    })();
+
+    var SUPPORT_EMAIL = 'info@apprendimentorapido.it';
+
+    var state = {
+        appointment: null,
+        slotsResponse: null,
+        rescheduleFascia: 'tutti',
+        rescheduleExtended: false,
+        selectedSlotIso: null,
+        loading: false,
+    };
+
+    // ===== util DOM (no innerHTML) =====
+    function el(tag, attrs, children) {
+        var node = document.createElement(tag);
+        if (attrs) {
+            Object.keys(attrs).forEach(function (k) {
+                if (k === 'class') node.className = attrs[k];
+                else if (k.indexOf('on') === 0 && typeof attrs[k] === 'function') {
+                    node.addEventListener(k.substring(2), attrs[k]);
+                } else if (k === 'disabled') {
+                    if (attrs[k]) node.setAttribute('disabled', 'disabled');
+                } else {
+                    node.setAttribute(k, attrs[k]);
+                }
+            });
+        }
+        if (children) {
+            (Array.isArray(children) ? children : [children]).forEach(function (c) {
+                if (c == null) return;
+                if (typeof c === 'string') node.appendChild(document.createTextNode(c));
+                else node.appendChild(c);
+            });
+        }
+        return node;
+    }
+
+    function clearStage() { while (stage.firstChild) stage.removeChild(stage.firstChild); }
+
+    function renderError(title, message, opts) {
+        clearStage();
+        var box = el('div', { class: 'result error' });
+        box.appendChild(el('h2', null, title));
+        box.appendChild(el('p', null, message));
+        if (!(opts && opts.hideContact)) {
+            box.appendChild(el('p', null, 'Per assistenza scrivi a ' + SUPPORT_EMAIL + '.'));
+        }
+        var back = el('a', { class: 'btn btn-secondary', href: 'https://apprendimentorapido.it' }, 'Torna al sito');
+        box.appendChild(back);
+        stage.appendChild(box);
+    }
+
+    function renderResult(title, message) {
+        clearStage();
+        var box = el('div', { class: 'result success' });
+        box.appendChild(el('h2', null, title));
+        box.appendChild(el('p', null, message));
+        var back = el('a', { class: 'btn btn-primary', href: 'https://apprendimentorapido.it' }, 'Torna al sito');
+        box.appendChild(back);
+        stage.appendChild(box);
+    }
+
+    function setLoading(flag) {
+        state.loading = flag;
+        var btns = stage.querySelectorAll('button[data-loading-target="true"]');
+        for (var i = 0; i < btns.length; i++) {
+            if (flag) btns[i].setAttribute('disabled', 'disabled');
+            else btns[i].removeAttribute('disabled');
+        }
+    }
+
+    // ===== fetch wrapper =====
+    function api(path, options) {
+        options = options || {};
+        var url = BACKEND_URL + path;
+        return fetch(url, {
+            method: options.method || 'GET',
+            headers: { 'Content-Type': 'application/json' },
+            body: options.body ? JSON.stringify(options.body) : undefined,
+        }).then(function (r) {
+            return r.json().then(function (j) {
+                return { status: r.status, body: j };
+            }, function () {
+                return { status: r.status, body: null };
+            });
+        });
+    }
+
+    function errorMessageFor(status, body) {
+        var detail = body && body.detail;
+        var code = (detail && detail.error) || (body && body.error) || '';
+        switch (code) {
+            case 'token_expired':
+                return ['Link scaduto', 'Il link che hai usato è scaduto. Per modifiche scrivi a ' + SUPPORT_EMAIL + '.'];
+            case 'token_invalid_signature':
+            case 'token_malformed':
+                return ['Link non valido', 'Il link non è valido. Controlla di averlo copiato per intero.'];
+            case 'appointment_not_found':
+                return ['Appuntamento non trovato', 'Non riusciamo a trovare l\'appuntamento associato a questo link.'];
+            case 'appointment_already_cancelled':
+            case 'already_cancelled':
+                return ['Già cancellato', 'Questo appuntamento risulta già cancellato.'];
+            case 'cancel_cutoff_passed':
+                return ['Modifiche non più disponibili', 'A meno di 12 ore dall\'appuntamento non è più possibile cancellare. Scrivi a ' + SUPPORT_EMAIL + '.'];
+            case 'reschedule_cutoff_passed':
+                return ['Riprogrammazione non più disponibile', 'A meno di 24 ore dall\'appuntamento non è più possibile riprogrammare. Scrivi a ' + SUPPORT_EMAIL + '.'];
+            case 'max_reschedule_reached':
+                return ['Limite riprogrammazioni raggiunto', 'Hai già riprogrammato 2 volte. Per ulteriori cambi scrivi a ' + SUPPORT_EMAIL + '.'];
+            case 'invalid_reason':
+                return ['Motivo non valido', 'Il motivo selezionato non è valido. Riprova.'];
+            case 'slot_no_longer_available':
+            case 'new_start_iso_invalid':
+                return ['Orario non più disponibile', 'L\'orario selezionato non è più disponibile. Ricarica la pagina e riprova.'];
+            case 'weekend_not_allowed':
+                return ['Giorno non disponibile', 'Sabato e domenica non sono disponibili.'];
+            case 'rate_limit_exceeded':
+                return ['Troppe richieste', 'Hai fatto troppe richieste in poco tempo. Riprova tra qualche minuto.'];
+            default:
+                if (status === 503) return ['Servizio momentaneamente non disponibile', 'Riprova fra qualche minuto.'];
+                return ['Si è verificato un errore', 'Riprova fra poco oppure scrivi a ' + SUPPORT_EMAIL + '.'];
+        }
+    }
+
+    // ===== state renders =====
+    function renderAppointmentView() {
+        clearStage();
+        var a = state.appointment;
+        var card = el('div', { class: 'appointment-card' }, [
+            el('div', { class: 'label' }, 'Il tuo appuntamento'),
+            el('div', { class: 'when' }, a.data_ora_label || ''),
+            el('div', { class: 'meta' }, a.coach_name ? ['Con ', el('strong', null, a.coach_name)] : ''),
+            el('div', { class: 'reschedule-counter' }, 'Riprogrammazioni: ' + (a.reschedule_count || 0) + '/' + (a.max_reschedule || 2)),
+        ]);
+
+        var actions = el('div', { class: 'actions' });
+
+        var cancelBtn = el('button', {
+            class: 'btn btn-secondary',
+            'data-loading-target': 'true',
+            onclick: function () {
+                if (!a.can_cancel) return;
+                renderCancelFlow();
+            },
+        }, 'Annulla appuntamento');
+        if (!a.can_cancel) cancelBtn.setAttribute('disabled', 'disabled');
+
+        var reschedBtn = el('button', {
+            class: 'btn btn-primary',
+            'data-loading-target': 'true',
+            onclick: function () {
+                if (!a.can_reschedule) return;
+                loadSlotsAndRenderReschedule();
+            },
+        }, 'Riprogramma');
+        if (!a.can_reschedule) reschedBtn.setAttribute('disabled', 'disabled');
+
+        actions.appendChild(cancelBtn);
+        actions.appendChild(reschedBtn);
+
+        stage.appendChild(el('h2', { class: 'heading' }, 'Ciao' + (a.nome ? ' ' + a.nome : '') + ','));
+        stage.appendChild(el('p', { class: 'subheading' }, 'da qui puoi annullare o riprogrammare il tuo appuntamento.'));
+        stage.appendChild(card);
+        stage.appendChild(actions);
+
+        if (!a.can_cancel || !a.can_reschedule) {
+            var msg = '';
+            if (!a.can_cancel && a.cancel_blocked_reason === 'cancel_cutoff_passed') {
+                msg = 'A meno di 12 ore dall\'appuntamento non è più possibile cancellare.';
+            } else if (!a.can_reschedule && a.reschedule_blocked_reason === 'reschedule_cutoff_passed') {
+                msg = 'A meno di 24 ore non è più possibile riprogrammare.';
+            } else if (!a.can_reschedule && a.reschedule_blocked_reason === 'max_reschedule_reached') {
+                msg = 'Hai raggiunto il numero massimo di riprogrammazioni (2). Per ulteriori cambi scrivi a ' + SUPPORT_EMAIL + '.';
+            }
+            if (msg) stage.appendChild(el('div', { class: 'notice' }, msg));
+        }
+    }
+
+    function renderCancelFlow() {
+        clearStage();
+        var a = state.appointment;
+        stage.appendChild(el('h2', { class: 'heading' }, 'Vuoi annullare?'));
+        stage.appendChild(el('p', { class: 'subheading' }, 'Stai per annullare l\'appuntamento del ' + (a.data_ora_label || '') + '.'));
+
+        var form = el('div', { class: 'cancel-form' });
+        form.appendChild(el('label', { for: 'reason' }, 'Motivo (facoltativo)'));
+        var select = el('select', { id: 'reason' }, [
+            el('option', { value: '' }, '— Nessun motivo —'),
+            el('option', { value: 'Imprevisto / impossibilità' }, 'Imprevisto / impossibilità'),
+            el('option', { value: 'Cambio idea' }, 'Cambio idea'),
+            el('option', { value: 'Altro' }, 'Altro'),
+        ]);
+        form.appendChild(select);
+
+        var actions = el('div', { class: 'actions' });
+        var back = el('button', {
+            class: 'btn btn-link',
+            'data-loading-target': 'true',
+            onclick: function () { renderAppointmentView(); },
+        }, 'Indietro');
+        var confirm = el('button', {
+            class: 'btn btn-primary',
+            'data-loading-target': 'true',
+            onclick: function () {
+                if (!window.confirm('Sei sicuro di voler annullare l\'appuntamento?')) return;
+                doCancel(select.value || null);
+            },
+        }, 'Conferma annullamento');
+        actions.appendChild(back);
+        actions.appendChild(confirm);
+
+        stage.appendChild(form);
+        stage.appendChild(actions);
+    }
+
+    function doCancel(reason) {
+        setLoading(true);
+        api('/api/public/appointment/' + encodeURIComponent(token) + '/cancel', {
+            method: 'POST',
+            body: { reason: reason },
+        }).then(function (resp) {
+            setLoading(false);
+            if (resp.status === 200) {
+                renderResult('Appuntamento annullato', 'Ti abbiamo inviato una email di conferma.');
+                return;
+            }
+            var info = errorMessageFor(resp.status, resp.body);
+            renderError(info[0], info[1]);
+        });
+    }
+
+    function loadSlotsAndRenderReschedule() {
+        setLoading(true);
+        var url = '/api/public/appointment/' + encodeURIComponent(token) + '/slots'
+                + '?fascia=' + encodeURIComponent(state.rescheduleFascia)
+                + '&extend=' + (state.rescheduleExtended ? 'true' : 'false');
+        api(url).then(function (resp) {
+            setLoading(false);
+            if (resp.status === 200) {
+                state.slotsResponse = resp.body;
+                renderRescheduleFlow();
+                return;
+            }
+            var info = errorMessageFor(resp.status, resp.body);
+            renderError(info[0], info[1]);
+        });
+    }
+
+    function renderRescheduleFlow() {
+        clearStage();
+        stage.appendChild(el('h2', { class: 'heading' }, 'Scegli un nuovo orario'));
+        stage.appendChild(el('p', { class: 'subheading' }, 'Sabato e domenica esclusi. Mattina = entro le 13:00, pomeriggio = dopo.'));
+
+        var filter = el('div', { class: 'filter-toggle' });
+        ['tutti', 'mattina', 'pomeriggio'].forEach(function (opt) {
+            var btn = el('button', {
+                type: 'button',
+                'aria-pressed': state.rescheduleFascia === opt ? 'true' : 'false',
+                onclick: function () {
+                    state.rescheduleFascia = opt;
+                    state.selectedSlotIso = null;
+                    loadSlotsAndRenderReschedule();
+                },
+            }, opt === 'tutti' ? 'Tutto' : (opt.charAt(0).toUpperCase() + opt.slice(1)));
+            filter.appendChild(btn);
+        });
+        stage.appendChild(filter);
+
+        var slots = (state.slotsResponse && state.slotsResponse.slots_by_day) || [];
+        if (slots.length === 0) {
+            stage.appendChild(el('div', { class: 'notice' }, 'Nessuno slot disponibile in questa finestra. Prova ad estendere oppure scrivi a ' + SUPPORT_EMAIL + '.'));
+        } else {
+            slots.forEach(function (day) {
+                var grp = el('div', { class: 'day-group' });
+                grp.appendChild(el('h3', null, day.date_label || day.date_iso));
+                var list = el('div', { class: 'slot-list' });
+                day.slots.forEach(function (slot) {
+                    var inputId = 'slot-' + slot.start_iso.replace(/[^a-z0-9]/gi, '');
+                    var radio = el('input', {
+                        type: 'radio',
+                        name: 'slot',
+                        id: inputId,
+                        value: slot.start_iso,
+                        onchange: function () { state.selectedSlotIso = slot.start_iso; },
+                    });
+                    if (state.selectedSlotIso === slot.start_iso) radio.setAttribute('checked', 'checked');
+                    var lbl = el('label', { for: inputId }, slot.label || slot.start_iso);
+                    var wrap = el('div', { class: 'slot-radio' }, [radio, lbl]);
+                    list.appendChild(wrap);
+                });
+                grp.appendChild(list);
+                stage.appendChild(grp);
+            });
+        }
+
+        if (state.slotsResponse && state.slotsResponse.has_more && !state.rescheduleExtended) {
+            var moreBtn = el('button', {
+                class: 'btn btn-link',
+                onclick: function () {
+                    state.rescheduleExtended = true;
+                    loadSlotsAndRenderReschedule();
+                },
+            }, 'Mostra altri 7 giorni');
+            stage.appendChild(moreBtn);
+        }
+
+        var actions = el('div', { class: 'actions mt-20' });
+        var back = el('button', {
+            class: 'btn btn-link',
+            'data-loading-target': 'true',
+            onclick: function () { renderAppointmentView(); },
+        }, 'Indietro');
+        var confirm = el('button', {
+            class: 'btn btn-primary',
+            'data-loading-target': 'true',
+            onclick: function () {
+                if (!state.selectedSlotIso) {
+                    window.alert('Seleziona prima un orario.');
+                    return;
+                }
+                doReschedule(state.selectedSlotIso);
+            },
+        }, 'Conferma riprogrammazione');
+        actions.appendChild(back);
+        actions.appendChild(confirm);
+        stage.appendChild(actions);
+    }
+
+    function doReschedule(newStartIso) {
+        setLoading(true);
+        api('/api/public/appointment/' + encodeURIComponent(token) + '/reschedule', {
+            method: 'POST',
+            body: { new_start_iso: newStartIso },
+        }).then(function (resp) {
+            setLoading(false);
+            if (resp.status === 200) {
+                renderResult(
+                    'Appuntamento riprogrammato',
+                    'Nuovo orario: ' + (resp.body.new_data_ora_label || newStartIso) + '. Ti abbiamo inviato una email di conferma.'
+                );
+                return;
+            }
+            var info = errorMessageFor(resp.status, resp.body);
+            renderError(info[0], info[1]);
+        });
+    }
+
+    // ===== Mock data per dev/preview =====
+    var MOCKS = {
+        appointment: {
+            appuntamento_id: 'apt-mock',
+            contatto_id: 'cnt-mock',
+            nome: 'Marco', cognome: 'Rossi',
+            email: 'marco.rossi@example.com',
+            stato: 'confermato',
+            data_ora_iso: '2026-05-15T10:00:00+02:00',
+            data_ora_label: 'giovedì 15 maggio 2026 alle 10:00',
+            durata_minuti: 60,
+            zoom_join_url: 'https://zoom.us/j/123',
+            coach_name: 'Maurizio',
+            titolo: 'Coaching gratuito',
+            reschedule_count: 0,
+            max_reschedule: 2,
+            can_cancel: true,
+            can_reschedule: true,
+            cancel_blocked_reason: null,
+            reschedule_blocked_reason: null,
+            cancellation_reasons: ['Imprevisto / impossibilità', 'Cambio idea', 'Altro'],
+        },
+        cutoff_error: { status: 403, body: { detail: { error: 'cancel_cutoff_passed' } } },
+        max_reschedule: { status: 403, body: { detail: { error: 'max_reschedule_reached' } } },
+        success: 'success',
+    };
+
+    // ===== Bootstrap =====
+    function start() {
+        if (mockMode === 'appointment') {
+            state.appointment = MOCKS.appointment;
+            renderAppointmentView();
+            return;
+        }
+        if (mockMode === 'cutoff_error') {
+            var info = errorMessageFor(403, MOCKS.cutoff_error.body);
+            renderError(info[0], info[1]);
+            return;
+        }
+        if (mockMode === 'max_reschedule') {
+            var info2 = errorMessageFor(403, MOCKS.max_reschedule.body);
+            renderError(info2[0], info2[1]);
+            return;
+        }
+        if (mockMode === 'success') {
+            renderResult('Appuntamento annullato', 'Ti abbiamo inviato una email di conferma.');
+            return;
+        }
+
+        if (!token) {
+            renderError('Link non valido', 'Manca il token nel link.');
+            return;
+        }
+
+        api('/api/public/appointment/' + encodeURIComponent(token)).then(function (resp) {
+            if (resp.status === 200) {
+                state.appointment = resp.body;
+                renderAppointmentView();
+                return;
+            }
+            var info = errorMessageFor(resp.status, resp.body);
+            renderError(info[0], info[1]);
+        });
+    }
+
+    start();
+})();

--- a/appuntamento/style.css
+++ b/appuntamento/style.css
@@ -1,0 +1,335 @@
+/* Self-service gestione appuntamento — palette coerente brand sito */
+
+:root {
+    --color-bg: #F8F7F4;
+    --color-card: #ffffff;
+    --color-navy: #0D1B2A;
+    --color-navy-soft: #1a2c44;
+    --color-text: #1a1a2e;
+    --color-text-muted: #5a6a7a;
+    --color-accent: #00A988;
+    --color-accent-dark: #007a63;
+    --color-cta: #F2854B;
+    --color-cta-dark: #d96e36;
+    --color-warn: #B8973E;
+    --color-error: #c0392b;
+    --color-divider: #e2e6eb;
+    --shadow-card: 0 8px 24px rgba(13, 27, 42, 0.08);
+    --radius: 14px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    line-height: 1.5;
+    min-height: 100vh;
+}
+
+.page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 32px 20px 80px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.brand {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.brand h1 {
+    color: var(--color-navy);
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+}
+
+.stage {
+    background: var(--color-card);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-card);
+    padding: 32px 24px;
+    flex: 1;
+}
+
+@media (min-width: 600px) {
+    .stage { padding: 40px 36px; }
+}
+
+.brand-footer {
+    text-align: center;
+    margin-top: 24px;
+    color: var(--color-text-muted);
+    font-size: 13px;
+}
+
+.brand-footer a {
+    color: var(--color-accent-dark);
+    text-decoration: none;
+}
+.brand-footer a:hover { text-decoration: underline; }
+
+/* ============= Componenti ============= */
+
+.loader {
+    text-align: center;
+    padding: 40px 0;
+    color: var(--color-text-muted);
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--color-divider);
+    border-top-color: var(--color-accent);
+    border-radius: 50%;
+    margin: 0 auto 16px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.heading {
+    color: var(--color-navy);
+    font-size: 22px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+@media (min-width: 600px) { .heading { font-size: 26px; } }
+
+.subheading {
+    color: var(--color-text-muted);
+    font-size: 14px;
+    margin-bottom: 24px;
+}
+
+.appointment-card {
+    background: linear-gradient(135deg, #f4faf8 0%, #ffffff 100%);
+    border: 1px solid var(--color-divider);
+    border-radius: 10px;
+    padding: 20px 18px;
+    margin: 16px 0 28px;
+}
+
+.appointment-card .label {
+    color: var(--color-text-muted);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    margin-bottom: 4px;
+}
+
+.appointment-card .when {
+    color: var(--color-navy);
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.appointment-card .meta {
+    color: var(--color-text-muted);
+    font-size: 13px;
+    margin-top: 8px;
+}
+
+.appointment-card .meta strong { color: var(--color-text); font-weight: 600; }
+
+.appointment-card .reschedule-counter {
+    display: inline-block;
+    margin-top: 10px;
+    padding: 3px 10px;
+    background: rgba(184, 151, 62, 0.12);
+    color: var(--color-warn);
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.actions {
+    display: flex;
+    gap: 12px;
+    flex-direction: column;
+    margin-top: 8px;
+}
+
+@media (min-width: 480px) {
+    .actions { flex-direction: row; }
+    .actions > * { flex: 1; }
+}
+
+.btn {
+    appearance: none;
+    border: 0;
+    border-radius: 10px;
+    padding: 14px 20px;
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 120ms ease, transform 80ms ease, opacity 120ms;
+    text-align: center;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.btn:disabled,
+.btn[aria-disabled="true"] {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.btn-primary {
+    background: var(--color-cta);
+    color: #fff;
+}
+.btn-primary:not(:disabled):hover { background: var(--color-cta-dark); }
+
+.btn-secondary {
+    background: transparent;
+    color: var(--color-navy);
+    border: 1.5px solid var(--color-navy);
+}
+.btn-secondary:not(:disabled):hover { background: var(--color-navy); color: #fff; }
+
+.btn-link {
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 10px;
+    font-weight: 500;
+}
+.btn-link:hover { color: var(--color-navy); }
+
+.btn-block { width: 100%; }
+
+/* ===== Cancel flow ===== */
+.cancel-form { margin-top: 20px; }
+.cancel-form label {
+    display: block;
+    font-size: 13px;
+    color: var(--color-text-muted);
+    margin-bottom: 6px;
+}
+.cancel-form select {
+    width: 100%;
+    padding: 12px 14px;
+    border: 1px solid var(--color-divider);
+    border-radius: 8px;
+    background: #fff;
+    font-family: inherit;
+    font-size: 15px;
+    color: var(--color-text);
+    margin-bottom: 18px;
+}
+
+/* ===== Reschedule flow ===== */
+.filter-toggle {
+    display: flex;
+    gap: 6px;
+    background: #f1f3f6;
+    border-radius: 999px;
+    padding: 4px;
+    margin: 18px 0 22px;
+}
+
+.filter-toggle button {
+    flex: 1;
+    appearance: none;
+    border: 0;
+    background: transparent;
+    padding: 8px 12px;
+    border-radius: 999px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background 120ms;
+}
+
+.filter-toggle button[aria-pressed="true"] {
+    background: var(--color-navy);
+    color: #fff;
+}
+
+.day-group {
+    margin-bottom: 18px;
+}
+
+.day-group h3 {
+    color: var(--color-navy);
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 10px;
+    text-transform: capitalize;
+}
+
+.slot-list {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+}
+
+.slot-radio {
+    position: relative;
+}
+.slot-radio input { position: absolute; opacity: 0; pointer-events: none; }
+.slot-radio label {
+    display: block;
+    padding: 12px 8px;
+    text-align: center;
+    border: 1.5px solid var(--color-divider);
+    border-radius: 8px;
+    background: #fff;
+    color: var(--color-navy);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 120ms, background 120ms;
+}
+.slot-radio input:checked + label {
+    border-color: var(--color-accent);
+    background: rgba(0, 169, 136, 0.10);
+    color: var(--color-accent-dark);
+}
+
+/* ===== Result / errori ===== */
+.result {
+    text-align: center;
+    padding: 24px 8px;
+}
+.result h2 {
+    color: var(--color-navy);
+    font-size: 22px;
+    margin-bottom: 12px;
+}
+.result.success h2 { color: var(--color-accent-dark); }
+.result.error h2 { color: var(--color-error); }
+.result p { color: var(--color-text-muted); margin-bottom: 18px; }
+
+.notice {
+    background: rgba(184, 151, 62, 0.08);
+    border-left: 3px solid var(--color-warn);
+    padding: 10px 14px;
+    color: var(--color-text);
+    font-size: 13px;
+    border-radius: 6px;
+    margin: 16px 0;
+}
+
+.notice.error {
+    background: rgba(192, 57, 43, 0.06);
+    border-left-color: var(--color-error);
+}
+
+/* utility */
+.mt-12 { margin-top: 12px; }
+.mt-20 { margin-top: 20px; }
+.mb-16 { margin-bottom: 16px; }
+.text-center { text-align: center; }


### PR DESCRIPTION
…+ JS vanilla)

- appuntamento/index.html: pagina pubblica self-service, niente bundler. Meta tag backend-url override-abile per staging. GA4 ereditato dal sito.
- appuntamento/style.css: palette brand (azzurro, navy, accent teal, arancio CTA Eureka), Montserrat, mobile-first 320px, system stack fallback. Componenti: appointment-card, slot-radio (selezione visiva), filter-toggle (mattina/pomeriggio/tutto), notice/error, spinner.
- appuntamento/manage.js: vanilla JS (no framework, no innerHTML), 5 stati (loading, view, cancel, reschedule, result). Errori mappati a messaggi user-friendly (token_*, cutoff, max_reschedule, rate_limit, weekend_not_allowed). Bottoni disabled durante chiamate API. Conferma prima di cancel.
- Mock querystring per preview senza backend live: ?mock=appointment | ?mock=cutoff_error | ?mock=max_reschedule | ?mock=success.

Apri localmente:
  start D:/progetti/sito-eureka-self-service-fe/appuntamento/index.html?mock=appointment

Branch base: staging (NON main, regola feedback_deploy_sito.md).